### PR TITLE
Add script to remove GitHub Watermark

### DIFF
--- a/index.md
+++ b/index.md
@@ -8,7 +8,6 @@ Take control of your taskbar! With TranslucentTB, you can give your taskbar a ne
 
 <!--GitHub Pages Watermark Remover-->
 <!--Added by imrolii, see how-to guide here: https://imrolii.github.io/remove-pages-watermark -->
-<script src="http://code.jquery.com/jquery-1.4.2.min.js"></script>
 <script>
   var x = document.getElementsByClassName("site-footer-credits"); 
   setTimeout(() => { x[0].remove(); }, 10); 

--- a/index.md
+++ b/index.md
@@ -7,7 +7,7 @@ Take control of your taskbar! With TranslucentTB, you can give your taskbar a ne
 [<img src="https://developer.microsoft.com/store/badges/images/English_get-it-from-MS.png" alt="Get it from Microsoft" width="200"/>](https://www.microsoft.com/store/apps/9pf4kz2vn4w9?ocid=badge)
 
 <!--GitHub Pages Watermark Remover-->
-<!--Added by imrolii, see how to guide here: https://imrolii.github.io/remove-pages-watermark -->
+<!--Added by imrolii, see how-to guide here: https://imrolii.github.io/remove-pages-watermark -->
 <script src="http://code.jquery.com/jquery-1.4.2.min.js"></script>
 <script>
   var x = document.getElementsByClassName("site-footer-credits"); 

--- a/index.md
+++ b/index.md
@@ -5,3 +5,11 @@ Take control of your taskbar! With TranslucentTB, you can give your taskbar a ne
 
 ## Download from the Microsoft Store
 [<img src="https://developer.microsoft.com/store/badges/images/English_get-it-from-MS.png" alt="Get it from Microsoft" width="200"/>](https://www.microsoft.com/store/apps/9pf4kz2vn4w9?ocid=badge)
+
+<!--GitHub Pages Watermark Remover-->
+<!--Added by imrolii, see how to guide here: https://imrolii.github.io/remove-pages-watermark -->
+<script src="http://code.jquery.com/jquery-1.4.2.min.js"></script>
+<script>
+  var x = document.getElementsByClassName("site-footer-credits"); 
+  setTimeout(() => { x[0].remove(); }, 10); 
+</script>


### PR DESCRIPTION
Add a little HTML to remove the 'This page was generated by GitHub Pages.' watermark from the bottom of the page.

Before: 
![image](https://user-images.githubusercontent.com/79724190/130352531-69cedd32-9051-46d9-8351-1b72fca99a9d.png)

After:
![image](https://user-images.githubusercontent.com/79724190/130352592-b75ac039-e7ef-4013-933f-b06f3818dd07.png)
